### PR TITLE
Add 32 already in line above. This is resulting in a duplicate operator

### DIFF
--- a/tensorflow/core/kernels/cwise_op_add_1.cc
+++ b/tensorflow/core/kernels/cwise_op_add_1.cc
@@ -21,8 +21,6 @@ REGISTER6(BinaryOp, CPU, "Add", functor::add, float, Eigen::half, double, int32,
 REGISTER6(BinaryOp, CPU, "AddV2", functor::add, float, Eigen::half, double,
           int32, int64, bfloat16);
 
-REGISTER(BinaryOp, CPU, "Add", functor::add, int32);
-
 #if GOOGLE_CUDA
 REGISTER3(BinaryOp, GPU, "Add", functor::add, float, Eigen::half, double);
 REGISTER3(BinaryOp, GPU, "AddV2", functor::add, float, Eigen::half, double);


### PR DESCRIPTION
Add 32 doubly defined. Results in an error on linux testing toy and in android build.  See line 19.